### PR TITLE
ensure always displays two decimals for unit price

### DIFF
--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -2,6 +2,11 @@ class InvoiceItemSerializer < ActiveModel::Serializer
   attributes :id, :item_id, :invoice_id, :quantity, :unit_price
 
   def unit_price
-    (object.unit_price.to_f / 100).to_s
+    dollars = (object.unit_price.to_f / 100).to_s
+    two_decimals(dollars)
+  end
+
+  def two_decimals(dollars)
+    '%.2f' % dollars
   end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -2,6 +2,12 @@ class ItemSerializer < ActiveModel::Serializer
   attributes :id, :name, :description, :unit_price, :merchant_id
 
   def unit_price
-    (object.unit_price.to_f / 100).to_s
+    dollars = (object.unit_price.to_f / 100).to_s
+    two_decimals(dollars)
   end
+
+  def two_decimals(dollars)
+    '%.2f' % dollars
+  end
+  
 end

--- a/app/serializers/merchant_revenue_serializer.rb
+++ b/app/serializers/merchant_revenue_serializer.rb
@@ -2,6 +2,11 @@ class MerchantRevenueSerializer < ActiveModel::Serializer
   attributes :revenue
 
   def revenue
-    (object[:revenue].to_f / 100).to_s
+    dollars = (object[:revenue].to_f / 100).to_s
+    two_decimals(dollars)
+  end
+
+  def two_decimals(dollars)
+    '%.2f' % dollars
   end
 end

--- a/spec/requests/api/v1/business_analytics/merchant_total_revenue_spec.rb
+++ b/spec/requests/api/v1/business_analytics/merchant_total_revenue_spec.rb
@@ -14,7 +14,7 @@ describe "when you visit a merchants revenue page" do
     revenue = JSON.parse(response.body)["revenue"]
 
     expect(response).to be_success
-    expect(revenue).to eq("36.9")
+    expect(revenue).to eq("36.90")
   end
 end
 
@@ -34,9 +34,7 @@ describe "when you search for a single merchant's revenue on a specific date" do
     get "/api/v1/merchants/#{merchant.id}/revenue?date=2012-03-27T14:54:05.000Z"
 
     revenue = JSON.parse(response.body)["revenue"]
-    # total_invoice_revenue = merchant.total_revenue
     expect(response).to be_success
-    expect(revenue).to eq("0.3")
-    # expect(revenue).to_not eq(total_invoice_revenue)
+    expect(revenue).to eq("0.30")
   end
 end


### PR DESCRIPTION
👍 
- Changed tests to reflect 2 decimals for merchant_revenue 